### PR TITLE
Feature/issue19 memo confirm

### DIFF
--- a/app/controllers/memos_controller.rb
+++ b/app/controllers/memos_controller.rb
@@ -5,8 +5,24 @@ class MemosController < ApplicationController
     @memo = Memo.new
   end
 
+  def confirm
+    unless params[:memo].present? # memos/confirmに直接アクセスした場合の対応
+      redirect_to new_memo_path, error: "フォームから入力してください"
+      return
+    end
+
+    @memo = current_user.memos.build(memo_params)
+    if @memo.invalid? # バリデーションエラーがある場合
+      flash.now[:error] = "メモの作成に失敗しました😨"
+      render :new, status: :unprocessable_entity
+      return
+    end
+      Rails.logger.debug "confirmアクション Memo_params内容🎃🎃🎃: #{memo_params.inspect}" # デバッグ用ログ
+      render :confirm
+  end
+
   def create
-    Rails.logger.debug "Memo_params内容🌱🌱🌱: #{memo_params.inspect}" # デバッグ用ログ
+    Rails.logger.debug "createアクション Memo_params内容🌱🌱🌱: #{memo_params.inspect}" # デバッグ用ログ
     @memo = current_user.memos.build(memo_params)
     if @memo.save
       redirect_to new_memo_path, success: "メモを作成しました"

--- a/app/controllers/memos_controller.rb
+++ b/app/controllers/memos_controller.rb
@@ -1,5 +1,5 @@
 class MemosController < ApplicationController
-  before_action :require_login, only: %i[new create]
+  before_action :require_login, only: %i[new confirm create]
 
   def new
     @memo = Memo.new
@@ -7,27 +7,27 @@ class MemosController < ApplicationController
 
   def confirm
     unless params[:memo].present? # memos/confirmに直接アクセスした場合の対応
-      redirect_to new_memo_path, error: "フォームから入力してください"
+      redirect_to new_memo_path, error: "このアクセスは正しくありません"
       return
     end
 
     @memo = current_user.memos.build(memo_params)
     if @memo.invalid? # バリデーションエラーがある場合
-      flash.now[:error] = "メモの作成に失敗しました😨"
+      flash.now[:error] = "必須項目を入力してください🙏"
       render :new, status: :unprocessable_entity
       return
     end
-      Rails.logger.debug "confirmアクション Memo_params内容🎃🎃🎃: #{memo_params.inspect}" # デバッグ用ログ
+      Rails.logger.debug "confirmアクション Memo_params🎃🎃🎃: #{memo_params.inspect}" # デバッグ用ログ
       render :confirm
   end
 
   def create
-    Rails.logger.debug "createアクション Memo_params内容🌱🌱🌱: #{memo_params.inspect}" # デバッグ用ログ
+    Rails.logger.debug "createアクション Memo_params🌱🌱🌱: #{memo_params.inspect}" # デバッグ用ログ
     @memo = current_user.memos.build(memo_params)
     if @memo.save
-      redirect_to new_memo_path, success: "メモを作成しました"
+      redirect_to new_memo_path, success: "メモを保存しました✨"
     else
-      flash.now[:error] = "メモの作成に失敗しました"
+      flash.now[:error] = "メモの保存に失敗しました"
       render :new, status: :unprocessable_entity
     end
   end
@@ -37,6 +37,7 @@ class MemosController < ApplicationController
   def not_authenticated; end
 
   def memo_params
+    Rails.logger.debug "memo_params🐠🐠🐠: #{params.inspect}" # デバッグ用ログ
     params.require(:memo).permit(:emotion, :date, memo_content: [ :what, :why, :why_more, :how, :summary ])
   end
 end

--- a/app/views/memos/confirm.html.erb
+++ b/app/views/memos/confirm.html.erb
@@ -1,0 +1,64 @@
+<div class="bg-white py-24 sm:py-32">
+  <div class="mx-auto max-w-7xl px-6 lg:px-8">
+    <div class="mx-auto max-w-2xl lg:text-center">
+
+      <p class="mt-2 text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+        Memos#confirm　メモ確認
+      </p>
+      <br><br><br>
+      <%= form_with model: @memo, url: memos_path do |f| %>
+        <%= render 'shared/error_messages', object: f.object %>
+
+        <div class="bg-[#f4f4f4] rounded-lg p-6"> <!-- 角丸と背景色 -->
+          <br><br>
+          この内容でよろしいですか？
+
+          <br><br>
+          感情<br>
+          <%= @memo.emotion %>
+          <%= f.hidden_field :emotion, value: @memo.emotion %>
+
+          <br><br>
+          いつ（When）<br>
+          <%= @memo.date %>
+          <%= f.hidden_field :date, value: @memo.date %>
+
+
+          <br><br>
+          <%= f.fields_for :memo_content do |key| %>
+            何（What）<br>
+            <%= JSON.parse(@memo.memo_content)["what"] %>
+            <%= key.hidden_field 'what', value: JSON.parse(@memo.memo_content)["what"] %>
+
+            <br><br>
+            なぜ(Why)<br>
+            <%= JSON.parse(@memo.memo_content)["why"] %>
+            <%= key.hidden_field 'why', value: JSON.parse(@memo.memo_content)["why"] %>
+            
+            <br><br>
+            なぜをもっと深掘り<br>
+            <%= JSON.parse(@memo.memo_content)["why_more"] %>
+            <%= key.hidden_field 'why_more', value: JSON.parse(@memo.memo_content)["why_more"] %>
+
+            <br><br>
+            どのように(How)<br>
+            <%= JSON.parse(@memo.memo_content)["how"] %>
+            <%= key.hidden_field 'how', value: JSON.parse(@memo.memo_content)["how"] %>
+            
+            <br><br>
+            まとめ・気付き<br>
+            <%= simple_format JSON.parse(@memo.memo_content)["summary"] %>
+            <%= key.hidden_field 'summary', value: JSON.parse(@memo.memo_content)["summary"] %>
+          <% end %>
+
+        <br><br><br>
+          <%= f.submit nil, class: "btn btn-error" %>
+        <% end %>
+        <br>
+      </div>
+
+      <br>
+      <%= link_to "◀︎ 前のページに戻る　", :back, class: "btn btn-warning" %>
+    </div>
+  </div>
+</div>

--- a/app/views/memos/confirm.html.erb
+++ b/app/views/memos/confirm.html.erb
@@ -6,59 +6,82 @@
         Memos#confirm　メモ確認
       </p>
       <br><br><br>
-      <%= form_with model: @memo, url: memos_path do |f| %>
+      <%= form_with model: @memo, url: memos_path, local: true do |f| %>
         <%= render 'shared/error_messages', object: f.object %>
+          <br>
+          この内容でよろしいですか？
+          <br><br>
 
         <div class="bg-[#f4f4f4] rounded-lg p-6"> <!-- 角丸と背景色 -->
-          <br><br>
-          この内容でよろしいですか？
-
-          <br><br>
-          感情<br>
-          <%= @memo.emotion %>
+          <br>
+          <br>
+          <div class="badge badge-error badge-outline badge-lg w-full max-w-xs">
+          <%= @memo.emotion == "happy" ? "嬉しかったこと・いいね" : @memo.content %>
+          </div>
           <%= f.hidden_field :emotion, value: @memo.emotion %>
 
           <br><br>
+          <div class="text-gray-400">
           いつ（When）<br>
+          </div>
+          <div class="font-extrabold">
           <%= @memo.date %>
+          </div>
           <%= f.hidden_field :date, value: @memo.date %>
-
 
           <br><br>
           <%= f.fields_for :memo_content do |key| %>
+            <div class="text-gray-400">
             何（What）<br>
+            </div>
+            <div class="font-extrabold">
             <%= JSON.parse(@memo.memo_content)["what"] %>
+            </div>
             <%= key.hidden_field 'what', value: JSON.parse(@memo.memo_content)["what"] %>
 
             <br><br>
+            <div class="text-gray-400">
             なぜ(Why)<br>
+            </div>
+            <div class="font-extrabold">
             <%= JSON.parse(@memo.memo_content)["why"] %>
+            </div>
             <%= key.hidden_field 'why', value: JSON.parse(@memo.memo_content)["why"] %>
             
             <br><br>
+            <div class="text-gray-400">
             なぜをもっと深掘り<br>
+            </div>
+            <div class="font-extrabold">
             <%= JSON.parse(@memo.memo_content)["why_more"] %>
+            </div>
             <%= key.hidden_field 'why_more', value: JSON.parse(@memo.memo_content)["why_more"] %>
 
             <br><br>
+            <div class="text-gray-400">
             どのように(How)<br>
+            </div>
+            <div class="font-extrabold">
             <%= JSON.parse(@memo.memo_content)["how"] %>
+            </div>
             <%= key.hidden_field 'how', value: JSON.parse(@memo.memo_content)["how"] %>
             
             <br><br>
+            <div class="text-gray-400">
             まとめ・気付き<br>
+            </div>
+            <div class="font-extrabold">
             <%= simple_format JSON.parse(@memo.memo_content)["summary"] %>
+            </div>
             <%= key.hidden_field 'summary', value: JSON.parse(@memo.memo_content)["summary"] %>
           <% end %>
 
         <br><br><br>
-          <%= f.submit nil, class: "btn btn-error" %>
+          <%= f.submit "メモ保存", class: "btn btn-error" %>
+          <br>
         <% end %>
         <br>
       </div>
-
-      <br>
-      <%= link_to "◀︎ 前のページに戻る　", :back, class: "btn btn-warning" %>
     </div>
   </div>
 </div>

--- a/app/views/memos/new.html.erb
+++ b/app/views/memos/new.html.erb
@@ -20,7 +20,7 @@
       </dialog>
 
       <br><br><br>
-      <%= form_with model: @memo do |f| %>
+      <%= form_with model: @memo, url: confirm_memos_path, method: :post, data: { turbo: false } do |f| %>
         <%= render 'shared/error_messages', object: f.object %>
         <%= f.select :emotion, [["嬉しかったこと・いいね", "happy"]], { selected: "happy" }, class: "select select-error w-full max-w-xs" %>
 

--- a/app/views/memos/new.html.erb
+++ b/app/views/memos/new.html.erb
@@ -20,13 +20,13 @@
       </dialog>
 
       <br><br><br>
-      <%= form_with model: @memo, url: confirm_memos_path, method: :post, data: { turbo: false } do |f| %>
+      <%= form_with model: @memo, url: confirm_memos_path, data: { turbo: false } do |f| %>
         <%= render 'shared/error_messages', object: f.object %>
         <%= f.select :emotion, [["嬉しかったこと・いいね", "happy"]], { selected: "happy" }, class: "select select-error w-full max-w-xs" %>
 
         <br><br>
         いつ（When）<br>
-        <%= f.date_field :date, class: "input input-bordered w-full max-w-xs" %>
+        <%= f.date_field :date, value: Date.today, class: "input input-bordered w-full max-w-xs" %>
 
         <br><br>
         <%= f.fields_for :memo_content do |key| %>
@@ -51,11 +51,11 @@
           <% end %>
 
         <br><br><br>
-        <%= f.submit "確認する", class: "btn btn-error" %>
+        <%= f.submit "入力内容を確認する", class: "btn btn-error" %>
       <% end %>
 
       <br>
-      <%= link_to "◀︎ 前のページに戻る　", :back, class: "btn btn-warning" %>
+
     </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,10 @@ Rails.application.routes.draw do
   delete "logout", to: "user_sessions#destroy"
 
   resources :users, only: %i[new create]
-  resources :memos, only: %i[new create]
+  resources :memos, only: %i[new create] do
+    post :confirm, on: :collection
+    get :confirm, on: :collection
+  end
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 


### PR DESCRIPTION
新規作成画面で入力したデータを、確認ページ（memos/confirm）で表示
- [ ] ルーティング設定
DB保存前のため`collection`を使用

- [ ] 確認ページに直接アクセスした際、newページに遷移するよう設定
