### PR TITLE
Feature/issue52 pre mvp tuning

### DIFF
--- a/app/controllers/memos_controller.rb
+++ b/app/controllers/memos_controller.rb
@@ -25,7 +25,7 @@ class MemosController < ApplicationController
     Rails.logger.debug "createアクション Memo_params🌱🌱🌱: #{memo_params.inspect}" # デバッグ用ログ
     @memo = current_user.memos.build(memo_params)
     if @memo.save
-      redirect_to new_memo_path, success: "メモを保存しました✨"
+      redirect_to memos_path, success: "メモを保存しました✨"
     else
       flash.now[:error] = "メモの保存に失敗しました"
       render :new, status: :unprocessable_entity

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -6,8 +6,8 @@ class UserSessionsController < ApplicationController
   def create # ログイン
     @user = login(params[:email], params[:password])
 
-    if @user
-      redirect_to root_path, success: "ログインしました"
+    if @user.save
+      redirect_to memos_path(user_id: @user.id), success: "ログインしました"
     else
       redirect_to root_path, error: "ログインに失敗しました"
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,10 +5,11 @@ class UsersController < ApplicationController
     @user = User.new
   end
 
-  def create # ユーザー登録
+  def create
     @user = User.new(user_params)
     if @user.save
-      redirect_to root_path, success: "ユーザー登録が完了しました"
+      auto_login(@user)
+      redirect_to memos_path, success: "ユーザー登録が完了しました"
     else
       flash.now[:error] = "ユーザー登録ができませんでした"
       render :new, status: :unprocessable_entity

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,10 +3,10 @@ class User < ApplicationRecord
 
   has_many :memos, dependent: :destroy
 
-  validates :email, presence: true, uniqueness: true
-  validates :password, length: { minimum: 4 }, if: -> { new_record? || changes[:crypted_password] }
-  validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
-  validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
-  validates :first_name, presence: true
-  validates :last_name, presence: true
+  validates :email, presence: { message: "メールアドレスを入力してください" }, uniqueness: { message: "このメールアドレスはすでに使用されています" }
+  validates :password, length: { minimum: 4, message: "パスワードは4文字以上にしてください" }, if: -> { new_record? || changes[:crypted_password] }
+  validates :password, confirmation: { message: "確認用パスワードが一致していません" }, if: -> { new_record? || changes[:crypted_password] }
+  validates :password_confirmation, presence: { message: "確認用パスワードを入力してください" }, if: -> { new_record? || changes[:crypted_password] }
+  validates :first_name, presence: { message: "姓を入力してください" }
+  validates :last_name, presence: { message: "名を入力してください" }
 end

--- a/app/views/memos/index.html.erb
+++ b/app/views/memos/index.html.erb
@@ -21,7 +21,7 @@
             <div class="flex justify-start">
               <%= memo.date || "日付は未選択です" %>
             </div>
-            <%= link_to JSON.parse(memo.memo_content)["what"], memo_path(memo), id: memo.id, class: "link link-hover text-xl" %>
+            <%= link_to JSON.parse(memo.memo_content)["what"], memo_path(memo), id: memo.id, class: "btn glass btn-wide btn-lg" %>
             <div class="flex justify-end">
               <%= link_to "編集", edit_memo_path(memo), id: memo.id,  class: "btn btn-success mx-1" %>
               <%= link_to "削除", memo_path(memo), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: "btn btn-error float-right mx-1" %><br><br>

--- a/app/views/memos/index.html.erb
+++ b/app/views/memos/index.html.erb
@@ -24,7 +24,7 @@
             <%= link_to JSON.parse(memo.memo_content)["what"], memo_path(memo), id: memo.id, class: "link link-hover text-xl" %>
             <div class="flex justify-end">
               <%= link_to "編集", edit_memo_path(memo), id: memo.id,  class: "btn btn-success mx-1" %>
-              <%= link_to "削除", edit_memo_path(memo), id: memo.id, method: :delete, class: "btn btn-error float-right mx-1" %><br><br>
+              <%= link_to "削除", memo_path(memo), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: "btn btn-error float-right mx-1" %><br><br>
             </div>
           </div>
         <% end %><br><br>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -10,6 +10,7 @@
       <div class="bg-[#f4f4f4] rounded-lg p-6"> <!-- 角丸と背景色 -->
         <br><br>
         <%= form_with model: @user do |f| %>
+        <%= render 'shared/error_messages', object: f.object %>
           <%= f.label :last_name, "姓(*)", class: "label" %>
           <%= f.text_field :last_name, class: "input input-bordered w-full max-w-xs" %>
           <br>
@@ -22,7 +23,7 @@
           <%= f.email_field :email, class: "input input-bordered w-full max-w-xs" %>
           <br>
           <br>
-          <%= f.label :password, "パスワード(*)", class: "label" %>
+          <%= f.label :password, "パスワード（4文字以上）(*)", class: "label" %>
           <%= f.password_field :password, class: "input input-bordered w-full max-w-xs" %>
           <br>
           <br>


### PR DESCRIPTION
 - [ ] 新規登録後、ログイン後、メモの新規作成・編集後に一覧ページへ遷移するように変更
（変更前：topページ）
 
- [ ] ユーザー新規登録ページのバリデーションメッセージを表示するよう変更

- [ ] 一覧ページからのメモ削除機能を修正
（変更前：詳細ページからしかできなかった）

- [ ] 一覧ページのタイトルクリック幅を広げた
詳細ページへ飛びやすくするため。
