### PR TITLE
Feature/issue68 count memos and days

### DIFF
--- a/app/controllers/memos_controller.rb
+++ b/app/controllers/memos_controller.rb
@@ -35,7 +35,6 @@ class MemosController < ApplicationController
     @memos = current_user.memos.order(created_at: :desc).page(params[:page]).per(5)
     @total_memos = @memos.total_count # Kaminariのtotal_countで全体数を取得
     @streak_days = Memo.streak_days(current_user) # 連続記録
-    Rails.logger.debug("current_user👤: #{current_user.id}")
   end
 
   def show

--- a/app/controllers/memos_controller.rb
+++ b/app/controllers/memos_controller.rb
@@ -34,6 +34,8 @@ class MemosController < ApplicationController
     @latest_memo = current_user.memos.includes(:user).order(updated_at: :desc).first
     @memos = current_user.memos.order(created_at: :desc).page(params[:page]).per(5)
     @total_memos = @memos.total_count # Kaminariのtotal_countで全体数を取得
+    @streak_days = Memo.streak_days(current_user) # 連続記録
+    Rails.logger.debug("current_user👤: #{current_user.id}")
   end
 
   def show

--- a/app/controllers/memos_controller.rb
+++ b/app/controllers/memos_controller.rb
@@ -33,6 +33,7 @@ class MemosController < ApplicationController
   def index
     @latest_memo = current_user.memos.includes(:user).order(updated_at: :desc).first
     @memos = current_user.memos.includes(:user).order(created_at: :desc).page(params[:page]).per(5)
+    @total_memos = @memos.total_count # Kaminariのtotal_countで全体数を取得
   end
 
   def show

--- a/app/controllers/memos_controller.rb
+++ b/app/controllers/memos_controller.rb
@@ -32,7 +32,7 @@ class MemosController < ApplicationController
 
   def index
     @latest_memo = current_user.memos.includes(:user).order(updated_at: :desc).first
-    @memos = current_user.memos.includes(:user).order(created_at: :desc).page(params[:page]).per(5)
+    @memos = current_user.memos.order(created_at: :desc).page(params[:page]).per(5)
     @total_memos = @memos.total_count # Kaminariのtotal_countで全体数を取得
   end
 

--- a/app/models/memo.rb
+++ b/app/models/memo.rb
@@ -34,7 +34,7 @@ class Memo < ApplicationRecord
     Rails.logger.debug("今日🌞: #{today.all_day}")
 
     # 今日のメモだけでなく、過去のメモを全て取得する
-    user.memos.where('created_at <= ?', today.end_of_day).order(created_at: :desc).each do |memo|
+    user.memos.where("created_at <= ?", today.end_of_day).order(created_at: :desc).each do |memo|
       memo_date = memo.created_at.to_date # メモの日付を取得。時刻は除く。
       Rails.logger.debug("取得したメモの作成日📝: #{memo_date}")
       Rails.logger.debug("直前の日付👀: #{previous_date}")
@@ -55,7 +55,7 @@ class Memo < ApplicationRecord
 
       previous_date = memo_date
       Rails.logger.debug("previous_dateを更新📅: #{previous_date} = #{memo_date}")
-    
+
       if previous_date.nil?
         streak_count = 1 # 初回処理の場合
       elsif previous_date == memo_date || previous_date == memo_date - 1 # 直前の日付と同じか、連続している場合
@@ -64,7 +64,7 @@ class Memo < ApplicationRecord
         streak_count = 0
       end
     end
-    
+
     Rails.logger.debug("最終連続の記録streak_count🔵: #{streak_count}")
     streak_count
   end

--- a/app/models/memo.rb
+++ b/app/models/memo.rb
@@ -25,4 +25,32 @@ class Memo < ApplicationRecord
   def favorited_by?(user) # current_userがお気に入り登録しているかを確認
     memo_favorite&.user_id == user.id
   end
+
+  def self.streak_days(user) # 連続記録
+    Rails.logger.debug("DEBUG: streak_daysがよばれました。このユーザーに: #{user.id}")
+
+    # メモの作成日を取得し日時を日付に変換、日付の重複を削除。
+    dates = user.memos.order(created_at: :asc).pluck(:created_at).map(&:to_date).uniq
+    Rails.logger.debug("dates📅: #{dates} - USER👦: #{user.id}")
+
+    streak_count = 1 # 連続記録をカウントする
+    previous_date = nil # 直前の日付を保持する
+
+    dates.each do |date|
+      current_date = date
+      Rails.logger.debug("current_date🍎: #{current_date}, previous_date🍏: #{previous_date}, streak_count#️⃣: #{streak_count}")
+
+    if previous_date.nil? || current_date == previous_date + 1 # 直前の日付がnilの場合、または今日の日付が直前の日付+1の場合
+      streak_count += 1 unless previous_date.nil? # 直前の日付がnilではない時（直前の日付が入っている時）に、streak_countを+1する
+    elsif current_date > previous_date + 1 # 今日の日付が直前の日付+1よりも大きい場合(1日より空いている場合)
+      Rails.logger.debug "🐛:日付が空いたため中断" 
+      break # ループを抜ける
+    end
+
+      previous_date = current_date # 直前の日付 ＝　今日の日付に更新
+    end
+
+    Rails.logger.debug "DEBUG🔥: 最終的なstreak_count: #{streak_count}"
+    streak_count # 計算結果を返す
+  end
 end

--- a/app/models/memo.rb
+++ b/app/models/memo.rb
@@ -31,30 +31,20 @@ class Memo < ApplicationRecord
     streak_count = 0 # 連続記録をカウントする
     previous_date = nil # 直前の日付を保持する
 
-    Rails.logger.debug("今日🌞: #{today.all_day}")
-
     # 今日のメモだけでなく、過去のメモを全て取得する
     user.memos.where("created_at <= ?", today.end_of_day).order(created_at: :desc).each do |memo|
       memo_date = memo.created_at.to_date # メモの日付を取得。時刻は除く。
-      Rails.logger.debug("取得したメモの作成日📝: #{memo_date}")
-      Rails.logger.debug("直前の日付👀: #{previous_date}")
 
       if previous_date.nil? # 直前の日付がnilの場合
         streak_count = 1
-        Rails.logger.debug("初回処理 memo_date📕: #{memo_date}")
-        Rails.logger.debug("初回処理 streak_count📕: #{streak_count}")
       elsif memo_date == previous_date # 直前の日付と同じ場合
-        Rails.logger.debug("🔁: 重複した日付: #{memo_date} はスキップ")
       elsif memo_date == previous_date - 1 # 連続している場合
         streak_count += 1
-        Rails.logger.debug("連続記録🔥: #{streak_count}")
       else
-        Rails.logger.debug("途切れた日付🐛: #{memo_date}で記録終了")
         break
       end
 
       previous_date = memo_date
-      Rails.logger.debug("previous_dateを更新📅: #{previous_date} = #{memo_date}")
 
       if previous_date.nil?
         streak_count = 1 # 初回処理の場合
@@ -65,7 +55,6 @@ class Memo < ApplicationRecord
       end
     end
 
-    Rails.logger.debug("最終連続の記録streak_count🔵: #{streak_count}")
     streak_count
   end
 end

--- a/app/views/memo_favorites/index.html.erb
+++ b/app/views/memo_favorites/index.html.erb
@@ -1,3 +1,4 @@
+<br><h1 class=text-3xl>お気に入り</h1><br>
 <% if @memo_favorites.empty? %> <!-- お気に入りがない場合 -->
   お気に入りのメモはまだありません。<br>
   お気に入り登録をしてみましょう！<br><br>

--- a/app/views/memos/_count_memos.html.erb
+++ b/app/views/memos/_count_memos.html.erb
@@ -1,0 +1,5 @@
+<!-- 呼び出し元は memos#index-->
+<br>
+累計メモ数：<%= @total_memos %>件<i class="fa-solid fa-seedling"></i>　　
+連続記録日数：<%= @streak_days %>日<i class="fa-solid fa-sun"></i>
+<br>

--- a/app/views/memos/index.html.erb
+++ b/app/views/memos/index.html.erb
@@ -15,8 +15,7 @@
         </div>
 
         <br><br>
-        累計メモ数：<%= @total_memos %>件<i class="fa-solid fa-seedling"></i>　　
-        連続記録日数：<%= @streak_days %>日<i class="fa-solid fa-sun"></i><br>
+        <%= render "count_memos" %> <!-- メモ総数と連続記録日数 -->
         <% @memos.each do |memo| %> <!-- メモ一覧 -->
           <div id="memo-<%= memo.id %>">
             <div class="border p-3">
@@ -43,6 +42,7 @@
         <%= paginate @memos %> <!-- ページネーション -->
 
       <% else %> <!-- メモがない場合 -->
+      <%= render "count_memos" %><!-- メモ総数と連続記録日数 -->
         記録はまだありません。<br>
         メモを作成してみましょう！<br><br>
         <%= link_to "新規作成", new_memo_path, class: "btn" %>

--- a/app/views/memos/index.html.erb
+++ b/app/views/memos/index.html.erb
@@ -14,6 +14,8 @@
           <%= simple_format(JSON.parse(@latest_memo.memo_content)["summary"]) %> 
         </div>
 
+        <br><br>
+        累計メモ数：<%= @total_memos %>件<i class="fa-solid fa-seedling"></i>　　
         <% @memos.each do |memo| %> <!-- メモ一覧 -->
           <div id="memo-<%= memo.id %>">
             <div class="border p-3">

--- a/app/views/memos/index.html.erb
+++ b/app/views/memos/index.html.erb
@@ -2,7 +2,8 @@
   <div class="mx-auto max-w-7xl px-6 lg:px-8">
     <div class="mx-auto max-w-2xl lg:text-center">
       <% content_for :title, "メモ一覧" %>
-      
+
+      <h1 class=text-3xl>Memo一覧</h1><br>
       <% if @memos.present? %>
         <div class="border p-3 mb-10"> <!-- 最終更新のメモ -->
           最新の記録<br><br>
@@ -26,8 +27,12 @@
                 <div id="favorite-star-<%= memo.id %>">
                   <%= render "shared/favorite_star", memo: memo %> <!-- お気に入りの⭐️ -->
                 </div>
-                <%= link_to "編集", edit_memo_path(memo), class: "btn btn-success mx-1" %>
-                <%= link_to "削除", memo_path(memo), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: "btn btn-error float-right mx-1" %><br><br>
+                <%= link_to edit_memo_path(memo), class: "mx-2" do %>
+                <i class="fa-solid fa-pen-to-square"></i>
+                <% end %>
+                <%= link_to memo_path(memo), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: "mx-2" do %>
+                <i class="fa-solid fa-trash"></i>
+                <% end %>
               </div>
             </div>
           </div>

--- a/app/views/memos/index.html.erb
+++ b/app/views/memos/index.html.erb
@@ -16,6 +16,7 @@
 
         <br><br>
         累計メモ数：<%= @total_memos %>件<i class="fa-solid fa-seedling"></i>　　
+        連続記録日数：<%= @streak_days %>日<i class="fa-solid fa-sun"></i><br>
         <% @memos.each do |memo| %> <!-- メモ一覧 -->
           <div id="memo-<%= memo.id %>">
             <div class="border p-3">

--- a/app/views/memos/new.html.erb
+++ b/app/views/memos/new.html.erb
@@ -2,7 +2,7 @@
   <div class="mx-auto max-w-7xl px-6 lg:px-8">
     <div class="mx-auto max-w-2xl lg:text-center">
       <% content_for :title, "メモ作成" %>
-      メモ作成ページ
+      <h1 class=text-3xl>メモ作成</h1><br>
       <br><br>
       <button class="btn btn-outline btn-success" onclick="my_modal_2.showModal()">書き方例</button>
       <dialog id="my_modal_2" class="modal">

--- a/app/views/memos/show.html.erb
+++ b/app/views/memos/show.html.erb
@@ -2,6 +2,8 @@
   <div class="mx-auto max-w-7xl px-6 lg:px-8">
     <div class="mx-auto max-w-2xl lg:text-center">
       <% content_for :title, JSON.parse(@memo.memo_content)["what"] %>
+
+      <h1 class=text-3xl><%= "#{JSON.parse(@memo.memo_content)["what"]}の詳細" %></h1><br>
       <br><br>
       <%= link_to "編集", edit_memo_path(@memo), class: "btn btn-success"  %>
       ・

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,5 +1,5 @@
 <header>
-  <div class="navbar bg-base-100">
+  <div class="navbar bg-base-100 fixed top-0 left-0 w-full z-50">
     <div class="flex">
       <%= link_to '/' do %>
         <%= image_tag 'logo.png', alt: "Memo Sprout logo", class: "h-14 w-auto" %>

--- a/app/views/shared/_header_before_login.html.erb
+++ b/app/views/shared/_header_before_login.html.erb
@@ -1,5 +1,5 @@
 <header>
-  <div class="navbar bg-base-100">
+  <div class="pt-20"><div class="navbar bg-base-100 fixed top-0 left-0 w-full z-50">
     <div class="flex">
       <%= link_to '/' do %>
         <%= image_tag 'logo.png', alt: "Memo Sprout logo", class: "h-14 w-auto" %>

--- a/app/views/shared/_star_favorite.html.erb
+++ b/app/views/shared/_star_favorite.html.erb
@@ -1,6 +1,7 @@
 <%= link_to memo_favorite_path(current_user.memo_favorites.find_by(memo_id: memo.id)),
     id: "favorite-star-#{memo.id}",
-    data: { turbo_method: :delete } do %>
+    data: { turbo_method: :delete },
+    class: "mx-2" do %>
   <i class="fa-solid fa-star"></i> <!-- 黒い星 クリックでお気に入り解除-->
 <% end %>
 

--- a/app/views/shared/_star_unfavorite.html.erb
+++ b/app/views/shared/_star_unfavorite.html.erb
@@ -1,5 +1,6 @@
 <%= link_to memo_favorites_path(memo_id: memo.id),
     id: "favorite-star-#{memo.id}",
-    data: { turbo_method: :post } do %>
+    data: { turbo_method: :post },
+    class: "mx-2" do %>
   <i class="fa-regular fa-star"></i> <!-- 白い星 クリックでお気に入り登録 -->
 <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,6 +22,7 @@ module MemoSprout
     # in config/environments, which are processed later.
     #
     # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = 'Asia/Tokyo'
     # config.eager_load_paths << Rails.root.join("extras")
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,7 +22,7 @@ module MemoSprout
     # in config/environments, which are processed later.
     #
     # config.time_zone = "Central Time (US & Canada)"
-    config.time_zone = 'Asia/Tokyo'
+    config.time_zone = "Asia/Tokyo"
     # config.eager_load_paths << Rails.root.join("extras")
   end
 end


### PR DESCRIPTION
- [ ] メモ一覧ページに「累計メモ数」を表示

- [ ] メモ一覧ページに「連続記録日数」を表示

---

- [ ] 各ページにタイトルを表示（簡易）
何をするページか明示するため

- [ ] メモの削除・編集ボタンをアイコンに変更
デザインを整えるため

- [ ] ヘッダーを固定
下にスクロールした時にmenuを開きやすくするため

- [ ] タイムゾーンをTokyoに設定
メモの作成日の日付取得の際のずれを防ぐため