### PR TITLE
fix: 丸一日記録がない場合に連続記録を0にするよう修正

### DIFF
--- a/app/controllers/memos_controller.rb
+++ b/app/controllers/memos_controller.rb
@@ -32,7 +32,7 @@ class MemosController < ApplicationController
 
   def index
     @latest_memo = current_user.memos.includes(:user).order(updated_at: :desc).first
-    @memos = current_user.memos.order(created_at: :desc).page(params[:page]).per(5)
+    @memos = current_user.memos.order(created_at: :desc).page(params[:page]).per(10)
     @total_memos = @memos.total_count # Kaminariのtotal_countで全体数を取得
     @streak_days = Memo.streak_days(current_user) # 連続記録
   end

--- a/app/models/memo.rb
+++ b/app/models/memo.rb
@@ -29,15 +29,19 @@ class Memo < ApplicationRecord
   def self.streak_days(user) # 連続記録
     today = Date.today
     streak_count = 0 # 連続記録をカウントする
-    previous_date = nil # 直前の日付を保持する
+    previous_date = today + 1 # 初期値を明日に設定
 
     # 今日のメモだけでなく、過去のメモを全て取得する
     user.memos.where("created_at <= ?", today.end_of_day).order(created_at: :desc).each do |memo|
       memo_date = memo.created_at.to_date # メモの日付を取得。時刻は除く。
 
-      if previous_date.nil? # 直前の日付がnilの場合
-        streak_count = 1
-      elsif memo_date == previous_date # 直前の日付と同じ場合
+      if previous_date == today + 1 # 初回処理
+        Rails.logger.debug("preview_date初回処理: #{previous_date}")
+        if memo_date == today || memo_date == today - 1 # 今日か昨日の場合
+          streak_count += 1
+        else
+          return 0
+        end
       elsif memo_date == previous_date - 1 # 連続している場合
         streak_count += 1
       else
@@ -45,14 +49,6 @@ class Memo < ApplicationRecord
       end
 
       previous_date = memo_date
-
-      if previous_date.nil?
-        streak_count = 1 # 初回処理の場合
-      elsif previous_date == memo_date || previous_date == memo_date - 1 # 直前の日付と同じか、連続している場合
-        # 何もしない（streak_countをそのままにする）
-      else
-        streak_count = 0
-      end
     end
 
     streak_count

--- a/app/views/memos/_count_memos.html.erb
+++ b/app/views/memos/_count_memos.html.erb
@@ -1,5 +1,5 @@
 <!-- 呼び出し元は memos#index-->
 <br>
 累計メモ数：<%= @total_memos %>件<i class="fa-solid fa-seedling"></i>　　
-連続記録日数：<%= @streak_days %>日<i class="fa-solid fa-sun"></i>
+連続記録：<%= @streak_days %>日<i class="fa-solid fa-sun"></i>
 <br>


### PR DESCRIPTION
- [ ] 丸一日記録がない場合に連続記録を0にするよう修正
修正前：過去に記録が存在すると、記録がない日を挟んでも以前の連続記録が表示されていた