### PR TITLE
Feature/issue79 show last created date

### DIFF
--- a/app/controllers/memos_controller.rb
+++ b/app/controllers/memos_controller.rb
@@ -77,7 +77,11 @@ class MemosController < ApplicationController
 
   def destroy
     @memo = current_user.memos.find_by(id: params[:id])
-    @memo.destroy!
+    if @memo.destroy!
+    @total_memos = current_user.memos.count
+    @streak_days = Memo.streak_days(current_user)
+    @today_memo = Memo.today_memo?(current_user)
+    end
   end
 
   private

--- a/app/controllers/memos_controller.rb
+++ b/app/controllers/memos_controller.rb
@@ -34,7 +34,8 @@ class MemosController < ApplicationController
     @latest_memo = current_user.memos.includes(:user).order(updated_at: :desc).first
     @memos = current_user.memos.order(created_at: :desc).page(params[:page]).per(10)
     @total_memos = @memos.total_count # Kaminariのtotal_countで全体数を取得
-    @streak_days = Memo.streak_days(current_user) # 連続記録
+    @streak_days = Memo.streak_days(current_user) # 連続
+    @today_memo = Memo.today_memo?(current_user) # 今日のメモが存在するか？
   end
 
   def show

--- a/app/models/memo.rb
+++ b/app/models/memo.rb
@@ -53,4 +53,8 @@ class Memo < ApplicationRecord
 
     streak_count
   end
+
+  def self.today_memo?(user) # 今日のメモが存在するか？
+    user.memos.exists?(created_at: Date.today.all_day)
+  end
 end

--- a/app/models/memo.rb
+++ b/app/models/memo.rb
@@ -31,26 +31,34 @@ class Memo < ApplicationRecord
     streak_count = 0 # 連続記録をカウントする
     previous_date = today + 1 # 初期値を明日に設定
 
-    # 今日のメモだけでなく、過去のメモを全て取得する
-    user.memos.where("created_at <= ?", today.end_of_day).order(created_at: :desc).each do |memo|
-      memo_date = memo.created_at.to_date # メモの日付を取得。時刻は除く。
+    # メモの日付だけを取得。同じ日付は排除し、降順に並べる
+    uniq_dates = user.memos.where("created_at <= ?", today.end_of_day)
+                            .order(created_at: :desc)
+                            .pluck(:created_at)
+                            .map(&:to_date)
+                            .uniq
 
+    uniq_dates.each do |memo_date|
       if previous_date == today + 1 # 初回処理
         Rails.logger.debug("preview_date初回処理: #{previous_date}")
         if memo_date == today || memo_date == today - 1 # 今日か昨日の場合
+          Rails.logger.debug("memo_date⭕️: #{memo_date}")
           streak_count += 1
         else
           return 0
         end
       elsif memo_date == previous_date - 1 # 連続している場合
+        Rails.logger.debug("memo_date⭕️: #{memo_date} - streak_count: #{streak_count}")
         streak_count += 1
       else
+        Rails.logger.debug("memo_date❌: #{memo_date} - streak_count: #{streak_count}")
+        streak_count += 1
         break
       end
 
       previous_date = memo_date
     end
-
+Rails.logger.debug("streak_count🟡: #{streak_count}")
     streak_count
   end
 

--- a/app/views/memos/_count_memos.html.erb
+++ b/app/views/memos/_count_memos.html.erb
@@ -1,5 +1,10 @@
 <!-- 呼び出し元は memos#index-->
 <br>
-累計メモ数：<%= @total_memos %>件<i class="fa-solid fa-seedling"></i>　　
-連続記録：<%= @streak_days %>日<i class="fa-solid fa-sun"></i>
+累計メモ数　<i class="fa-solid fa-seedling"></i>　<%= @total_memos %>件<br><br>
+連続記録　<i class="fa-solid fa-sun"></i>　<%= @streak_days %>日<br>
+<% if @today_memo %> <!-- 今日のメモがあるか -->
+  （今日の記録はカウントされています✨）
+<% else %>
+  （今日の記録はまだありません。記録更新を目指しましょう！）</span>
+<% end %>
 <br>

--- a/app/views/memos/_count_memos.html.erb
+++ b/app/views/memos/_count_memos.html.erb
@@ -1,10 +1,12 @@
 <!-- 呼び出し元は memos#index-->
-<br>
-累計メモ数　<i class="fa-solid fa-seedling"></i>　<%= @total_memos %>件<br><br>
-連続記録　<i class="fa-solid fa-sun"></i>　<%= @streak_days %>日<br>
-<% if @today_memo %> <!-- 今日のメモがあるか -->
-  （今日の記録はカウントされています✨）
-<% else %>
-  （今日の記録はまだありません。記録更新を目指しましょう！）</span>
-<% end %>
-<br>
+<div id="count_memos">
+  <br>
+  累計メモ数　<i class="fa-solid fa-seedling"></i>　<%= @total_memos %>件<br><br>
+  連続記録　<i class="fa-solid fa-sun"></i>　<%= @streak_days %>日<br>
+  <% if @today_memo %> <!-- 今日のメモがあるか -->
+    （今日の記録はカウントされています✨）
+  <% else %>
+    （今日の記録はまだありません。記録更新を目指しましょう！）</span>
+  <% end %>
+  <br>
+</div>

--- a/app/views/memos/create.turbo_stream.erb
+++ b/app/views/memos/create.turbo_stream.erb
@@ -1,0 +1,2 @@
+<!-- 呼び出し元は memo_favorites#create -->
+<%= turbo_stream.replace "memo-#{@memo.id}" %>

--- a/app/views/memos/destroy.turbo_stream.erb
+++ b/app/views/memos/destroy.turbo_stream.erb
@@ -1,2 +1,3 @@
 <!-- 呼び出し元は memos#destroy -->
 <%= turbo_stream.remove "memo-#{@memo.id}" %>
+<%= turbo_stream.replace "count_memos", partial: "memos/count_memos" %>

--- a/app/views/memos/index.html.erb
+++ b/app/views/memos/index.html.erb
@@ -32,7 +32,7 @@
                 <%= link_to edit_memo_path(memo), class: "mx-2" do %>
                 <i class="fa-solid fa-pen-to-square"></i>
                 <% end %>
-                <%= link_to memo_path(memo), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: "mx-2" do %>
+                <%= link_to memo_path(memo), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？\n※削除すると連続記録が失われる場合があります。" }, class: "mx-2" do %>
                 <i class="fa-solid fa-trash"></i>
                 <% end %>
               </div>

--- a/app/views/memos/index.html.erb
+++ b/app/views/memos/index.html.erb
@@ -3,7 +3,7 @@
     <div class="mx-auto max-w-2xl lg:text-center">
       <% content_for :title, "メモ一覧" %>
 
-      <h1 class=text-3xl>Memo一覧</h1><br>
+      <h1 class="text-3xl">Memo一覧</h1><br>
       <% if @memos.present? %>
         <div class="border p-3 mb-10"> <!-- 最終更新のメモ -->
           最新の記録<br><br>
@@ -24,16 +24,13 @@
               </div>
               <!-- タイトル（Whatの内容）-->
               <%= link_to JSON.parse(memo.memo_content)["what"], memo_path(memo), id: memo.id, class: "btn glass btn-wide btn-lg" %>
-
               <div class="flex justify-end">
-                <div id="favorite-star-<%= memo.id %>">
-                  <%= render "shared/favorite_star", memo: memo %> <!-- お気に入りの⭐️ -->
-                </div>
+                <%= render "shared/favorite_star", memo: memo %> <!-- お気に入りの⭐️ -->
                 <%= link_to edit_memo_path(memo), class: "mx-2" do %>
-                <i class="fa-solid fa-pen-to-square"></i>
+                  <i class="fa-solid fa-pen-to-square"></i>
                 <% end %>
                 <%= link_to memo_path(memo), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？\n\n※このメモが連続記録日数に含まれている場合、\n　記録が途切れる可能性があります。" }, class: "mx-2" do %>
-                <i class="fa-solid fa-trash"></i>
+                  <i class="fa-solid fa-trash"></i>
                 <% end %>
               </div>
             </div>

--- a/app/views/memos/index.html.erb
+++ b/app/views/memos/index.html.erb
@@ -32,7 +32,7 @@
                 <%= link_to edit_memo_path(memo), class: "mx-2" do %>
                 <i class="fa-solid fa-pen-to-square"></i>
                 <% end %>
-                <%= link_to memo_path(memo), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？\n※削除すると連続記録が失われる場合があります。" }, class: "mx-2" do %>
+                <%= link_to memo_path(memo), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？\n\n※このメモが連続記録日数に含まれている場合、\n　記録が途切れる可能性があります。" }, class: "mx-2" do %>
                 <i class="fa-solid fa-trash"></i>
                 <% end %>
               </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -16,7 +16,7 @@
           <details class="relative"> <!-- relative：子要素の絶対位置を指定 -->
             <summary>Menu</summary>
             <ul class="bg-base-100 rounded-t-none p-2 w-44 min-w-max absolute right-0">
-              <li><%= link_to "記録一覧", memos_path %></li>
+              <li><%= link_to "メモ一覧", memos_path %></li>
               <li>
                 <div class="tooltip tooltip-left" data-tip="アップデートをお待ちください">
                   使い方

--- a/app/views/shared/_header_before_login.html.erb
+++ b/app/views/shared/_header_before_login.html.erb
@@ -15,7 +15,7 @@
           <ul class="bg-base-100 rounded-t-none p-2 w-44 min-w-max absolute right-0">
               <li>
                 <div class="tooltip tooltip-left" data-tip="ログイン後に使える機能です">
-                  <a>記録一覧</a>
+                  <a>メモ一覧</a>
                 </div>
               </li>
               <li>


### PR DESCRIPTION
- [ ] 今日のメモが作成済みかどうかをメッセージの出し分けで表示
連続記録が更新されているかどうかを分かりやすくするため

- [ ] ヘッダーメニューの表示名変更
記録一覧 → メモ一覧

- [ ] メモ削除時のモーダル文を変更
「削除すると連続記録が失われる可能性があります」を追加

- [ ] **fix:** 同じ日に2回以上記録した時の連続記録を正しく表示
同日に2回以上の記録で、連続記録がその日からになってしまっていたため

- [ ] メモを削除した際にmemoの総数と連続記録もturboで連動するように修正
