### PR TITLE
add: パスワード入力フォームにautocompleteを設定

### DIFF
--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -26,12 +26,13 @@
           <br><div class="divider text-gray-500 text-sm"><%= t('.or') %></div><br>
 
           <%= form_with url: login_path, method: :post, local: true do |f| %>
-            <%= f.label :email, t('.email'), class: "label" %>
-            <%= f.email_field :email, placeholder: "memosprout@example.com", class: "input input-bordered w-full max-w-xs" %>
+            <%= f.label :email, t('activerecord.attributes.user.email'), class: "label" %>
+            <%= f.email_field :email, placeholder: "memosprout@example.com", autocomplete: "email", class: "input input-bordered w-full max-w-xs" %>
             <br>
+
             <br>
-            <%= f.label :password, t('.password'), class: "label" %>
-            <%= f.password_field :password, class: "input input-bordered w-full max-w-xs" %>
+            <%= f.label :password, t('activerecord.attributes.user.password'), class: "label" %>
+            <%= f.password_field :password, autocomplete: "current-password", class: "input input-bordered w-full max-w-xs" %>
             <br><br>
             <div class="tooltip" data-tip="アップデートをお待ちください">
               <!-- パスワードをお忘れの方はこちら -->

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -22,12 +22,12 @@
           <br>
           <!-- メールアドレス -->
           <%= f.label :email, "#{I18n.t('activerecord.attributes.user.email')} (*)", class: "label" %>
-          <%= f.email_field :email, class: "input input-bordered w-full max-w-xs" %>
+          <%= f.email_field :email, autocomplete: "email", class: "input input-bordered w-full max-w-xs" %>
           <br>
           <br>
           <!-- パスワード / (※4文字以上) -->
           <%= f.label :password, "#{I18n.t('activerecord.attributes.user.password')} (*)#{I18n.t('activerecord.helpers.hints.user.password')}", class: "label" %>
-          <%= f.password_field :password, class: "input input-bordered w-full max-w-xs" %>
+          <%= f.password_field :password, autocomplete: "new-password", class: "input input-bordered w-full max-w-xs" %>
           <br>
           <br>
           <!-- パスワード（再入力） -->


### PR DESCRIPTION
- [ ] loginフォーム、 ユーザー新規登録フォームに `autocomplete`を設定
ブラウザの検証モードに表示された `autocomplete`の設定推奨の警告を受け、
ユーザーエクスペリエンスの向上、ブラウザのセキュリティ機能を活用するため。
